### PR TITLE
Remove Bearer from JWT if exist

### DIFF
--- a/middleware/authentication/adapters/jwt.js
+++ b/middleware/authentication/adapters/jwt.js
@@ -21,6 +21,12 @@ module.exports = function(adapterId, adapterType, config)
             value = req.cookies[config.cookie.toLowerCase()];
         }
 
+        // Strip Bearer from JWT if exist
+        if (value.substr(0, 7) === 'Bearer ')
+        {
+            value = value.substr(7)
+        }
+
         if (!value)
         {
             return null;


### PR DESCRIPTION
The standard format for sending JWT tokens is `Bearer {token}`. This removes the "Bearer " from JWT if exist.
https://jwt.io/introduction/#how-do-json-web-tokens-work-